### PR TITLE
Simulator preparation methods are a little garbage happy.

### DIFF
--- a/KerbalEngineer/Extensions/PartExtensions.cs
+++ b/KerbalEngineer/Extensions/PartExtensions.cs
@@ -571,7 +571,26 @@ namespace KerbalEngineer.Extensions
         /// </summary>
         public static bool IsSepratron(this Part part)
         {
-            return IsSolidRocket(part) && part.ActivatesEvenIfDisconnected && IsDecoupledInStage(part, part.inverseStage);
+            for (int i = 0; i < part.Modules.Count; i++)
+            {
+                if (part.Modules[i] is ModuleEngines)
+                {
+                    if ((part.Modules[i] as ModuleEngines).throttleLocked)
+                        return true;
+                }
+            }
+            return false;
+        }
+
+        public static bool ContainedPart(this Part part, List<Part> chain)
+        {
+            for (int i = 0; i < chain.Count; i++)
+            {
+                if (chain[i] == part)
+                    return true;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/KerbalEngineer/VesselSimulator/PartSim.cs
+++ b/KerbalEngineer/VesselSimulator/PartSim.cs
@@ -44,6 +44,8 @@ namespace KerbalEngineer.VesselSimulator {
         public bool hasModuleEngines;
         public bool hasMultiModeEngine;
 
+        List<Part> chain = new List<Part>(); //prolly dont need a list, just the previous part but whatever.
+
         public bool hasVessel;
         public String initialVesselName;
         public int inverseStage;
@@ -121,7 +123,7 @@ namespace KerbalEngineer.VesselSimulator {
             partSim.decoupledInStage = partSim.DecoupledInStage(p);
             partSim.isFuelLine = p.HasModule<CModuleFuelLine>();
             partSim.isRCS = p.HasModule<ModuleRCS>() || p.HasModule<ModuleRCSFX>(); //I don't think it checks inheritance.
-            partSim.isSepratron = partSim.IsSepratron();
+            partSim.isSepratron = p.IsSepratron();
             partSim.inverseStage = p.inverseStage;
             if (log != null) log.AppendLine("inverseStage = ", partSim.inverseStage);
             partSim.resPriorityOffset = p.resourcePriorityOffset;
@@ -863,7 +865,7 @@ namespace KerbalEngineer.VesselSimulator {
             if (original.parent == null)
                 return stage; //root part is always present. Fixes phantom stage if root is stageable.
 
-            List<Part> chain = new List<Part>(); //prolly dont need a list, just the previous part but whatever.
+            chain.Clear();
 
             while (thePart != null) {
 
@@ -881,7 +883,7 @@ namespace KerbalEngineer.VesselSimulator {
                             stage = thePart.inverseStage;
                         else {
                             if (att != null) {
-                                if ((thePart.parent != null && att.attachedPart == thePart.parent) || chain.Contains(att.attachedPart))
+                                if ((thePart.parent != null && att.attachedPart == thePart.parent) || att.attachedPart.ContainedPart(chain))
                                     stage = thePart.inverseStage;
                             } else stage = thePart.inverseStage;
                         }
@@ -891,7 +893,7 @@ namespace KerbalEngineer.VesselSimulator {
                     {
                         AttachNode att = thePart.FindAttachNode(manch.explosiveNodeID); // these stupid fuckers don't initialize in the Editor scene.
                         if (att != null) {
-                            if ((thePart.parent != null && att.attachedPart == thePart.parent) || chain.Contains(att.attachedPart))
+                            if ((thePart.parent != null && att.attachedPart == thePart.parent) || att.attachedPart.ContainedPart(chain))
                                 stage = thePart.inverseStage;
                         } else stage = thePart.inverseStage; //radial decouplers it seems the attach node ('surface') comes back null.
                     }
@@ -907,6 +909,8 @@ namespace KerbalEngineer.VesselSimulator {
 
                 thePart = thePart.parent;
             }
+
+            chain.Clear();
 
             return stage;
         }

--- a/KerbalEngineer/VesselSimulator/PartSim.cs
+++ b/KerbalEngineer/VesselSimulator/PartSim.cs
@@ -909,9 +909,7 @@ namespace KerbalEngineer.VesselSimulator {
 
                 thePart = thePart.parent;
             }
-
-            chain.Clear();
-
+            
             return stage;
         }
 


### PR DESCRIPTION
This replaces some stray Linq and makes the DecoupledInStage method generate far less garbage due to some list operations.

The stock Kerbal X was generating about 35kb of garbage every time the simulator ran, about 5 times per second. This update takes that down to about 2kb. More complex vessels could generate significantly more garbage.