### PR TITLE
use displayname rather than name

### DIFF
--- a/KerbalEngineer/CelestialBodies.cs
+++ b/KerbalEngineer/CelestialBodies.cs
@@ -37,7 +37,7 @@ namespace KerbalEngineer
             try
             {
                 SystemBody = new BodyInfo(PSystemManager.Instance.localBodies.Find(b => b.referenceBody == null || b.referenceBody == b));
-                String homeCBName = Planetarium.fetch.Home.bodyName;
+                String homeCBName = Planetarium.fetch.Home.bodyDisplayName.LocalizeRemoveGender();
                 if (!SetSelectedBody(homeCBName))
                 {
                     SelectedBody = SystemBody;
@@ -103,7 +103,7 @@ namespace KerbalEngineer
                 {
                     // Set the body information.
                     CelestialBody = body;
-                    Name = body.bodyName;
+                    Name = body.bodyDisplayName.LocalizeRemoveGender();
                     Gravity = 9.81 * body.GeeASL;
                     Parent = parent;
 

--- a/KerbalEngineer/Flight/Readouts/Body/BodyName.cs
+++ b/KerbalEngineer/Flight/Readouts/Body/BodyName.cs
@@ -28,7 +28,7 @@ namespace KerbalEngineer.Flight.Readouts.Body {
             if (FlightGlobals.ActiveVessel.mainBody == null)
                 DrawLine("N/A", section.IsHud);
             else
-                DrawLine(FlightGlobals.ActiveVessel.mainBody.bodyName, section.IsHud);
+                DrawLine(FlightGlobals.ActiveVessel.mainBody.bodyDisplayName.LocalizeRemoveGender(), section.IsHud);
         }
     }
 }

--- a/KerbalEngineer/Flight/Readouts/Rendezvous/RendezvousProcessor.cs
+++ b/KerbalEngineer/Flight/Readouts/Rendezvous/RendezvousProcessor.cs
@@ -534,9 +534,9 @@ namespace KerbalEngineer.Flight.Readouts.Rendezvous {
                 mo = ((global::Vessel)tgt).mapObject;
 
             if (mo == null || mo.Discoverable == null)
-                return Localizer.Format("<<1>>", tgt.GetDisplayName());
+                return Localizer.Format("<<1>>", tgt.GetDisplayName().LocalizeRemoveGender());
             else
-                return Localizer.Format("<<1>>", mo.GetDisplayName());
+                return Localizer.Format("<<1>>", mo.GetDisplayName().LocalizeRemoveGender());
         }
 
         private double CalcInterceptAngle(Orbit targetOrbit, Orbit originOrbit) {

--- a/KerbalEngineer/Flight/Readouts/Rendezvous/TargetSelector.cs
+++ b/KerbalEngineer/Flight/Readouts/Rendezvous/TargetSelector.cs
@@ -114,12 +114,12 @@ namespace KerbalEngineer.Flight.Readouts.Rendezvous {
                     continue;
                 }
 
-                if (this.searchQuery.Length > 0 && !body.bodyName.ToLower().Contains(this.searchQuery)) {
+                if (this.searchQuery.Length > 0 && !body.bodyDisplayName.LocalizeRemoveGender().ToLower().Contains(this.searchQuery)) {
                     continue;
                 }
 
                 count++;
-                if (GUILayout.Button(body.bodyName, this.ButtonStyle, GUILayout.Width(this.ContentWidth))) {
+                if (GUILayout.Button(body.bodyDisplayName.LocalizeRemoveGender(), this.ButtonStyle, GUILayout.Width(this.ContentWidth))) {
                     this.SetTargetAs(body);
                 }
             }
@@ -136,12 +136,12 @@ namespace KerbalEngineer.Flight.Readouts.Rendezvous {
                     continue;
                 }
 
-                if (this.searchQuery.Length > 0 && !body.bodyName.ToLower().Contains(this.searchQuery)) {
+                if (this.searchQuery.Length > 0 && !body.bodyDisplayName.LocalizeRemoveGender().ToLower().Contains(this.searchQuery)) {
                     continue;
                 }
 
                 count++;
-                if (GUILayout.Button(body.GetName(), this.ButtonStyle, GUILayout.Width(this.ContentWidth))) {
+                if (GUILayout.Button(body.GetDisplayName().LocalizeRemoveGender(), this.ButtonStyle, GUILayout.Width(this.ContentWidth))) {
                     this.SetTargetAs(body);
                 }
             }
@@ -268,14 +268,14 @@ namespace KerbalEngineer.Flight.Readouts.Rendezvous {
 
                     if (RendezvousProcessor.sourceDisplay != null) {
                         if (RendezvousProcessor.landedSamePlanet || RendezvousProcessor.overrideANDN)
-                            this.DrawLine("Ref Orbit", "Landed on " + RendezvousProcessor.activeVessel.GetOrbit().referenceBody.GetName(), section.IsHud);
+                            this.DrawLine("Ref Orbit", "Landed on " + RendezvousProcessor.activeVessel.GetOrbit().referenceBody.GetDisplayName().LocalizeRemoveGender(), section.IsHud);
                         else
                             this.DrawLine("Ref Orbit", RendezvousProcessor.sourceDisplay, section.IsHud);
                     }
 
                     if (RendezvousProcessor.targetDisplay != null) {
                         if (RendezvousProcessor.landedSamePlanet || RendezvousProcessor.overrideANDNRev)
-                            this.DrawLine("Target Orbit", "Landed on " + target.GetOrbit().referenceBody.GetName(), section.IsHud);
+                            this.DrawLine("Target Orbit", "Landed on " + target.GetOrbit().referenceBody.GetDisplayName().LocalizeRemoveGender(), section.IsHud);
                         else
                             this.DrawLine("Target Orbit", RendezvousProcessor.targetDisplay, section.IsHud);
                     }
@@ -394,12 +394,12 @@ namespace KerbalEngineer.Flight.Readouts.Rendezvous {
                 if (this.searchQuery.Length == 0) {
                     count++;
 
-                    if (GUILayout.Button(vessel.GetName(), this.ButtonStyle, GUILayout.Width(this.ContentWidth))) {
+                    if (GUILayout.Button(vessel.GetDisplayName().LocalizeRemoveGender(), this.ButtonStyle, GUILayout.Width(this.ContentWidth))) {
                         this.SetTargetAs(vessel);
                     }
                 } else if (vessel.vesselName.ToLower().Contains(this.searchQuery)) {
                     count++;
-                    if (GUILayout.Button(vessel.GetName(), this.ButtonStyle, GUILayout.Width(this.ContentWidth))) {
+                    if (GUILayout.Button(vessel.GetDisplayName().LocalizeRemoveGender(), this.ButtonStyle, GUILayout.Width(this.ContentWidth))) {
                         this.SetTargetAs(vessel);
                     }
                 }

--- a/KerbalEngineer/Flight/Readouts/Surface/Situation.cs
+++ b/KerbalEngineer/Flight/Readouts/Surface/Situation.cs
@@ -82,7 +82,7 @@ namespace KerbalEngineer.Flight.Readouts.Surface
 
         private static string GetBodyPlural()
         {
-            return FlightGlobals.currentMainBody.bodyName.EndsWith("s") ? FlightGlobals.currentMainBody.bodyName + "\'" : FlightGlobals.currentMainBody.bodyName + "\'s";
+            return FlightGlobals.currentMainBody.bodyDisplayName.LocalizeRemoveGender().EndsWith("s") ? FlightGlobals.currentMainBody.bodyDisplayName.LocalizeRemoveGender() + "\'" : FlightGlobals.currentMainBody.bodyDisplayName.LocalizeRemoveGender() + "\'s";
         }
 
         #endregion


### PR DESCRIPTION
this is an attempt to use displayName rather than name

I did some testing (not too much tho) and it seems to work fine

this uses the localizator a lot so it might not be the best idea for performance (I wouldn't know)

an alternative would be to just build a dictionary and then read the displayNames from there

(Dictionary<string, string> where the Key is name and the Value is displayName)

if you do this I would suggest you to build the dictionary not at the Start() of MainMenu but at the start of SpaceCenter. This should allow you to avoid reading the names before Kopernicus has a chance to edit them