### PR TITLE
Add check for DeltaVGlobals

### DIFF
--- a/KerbalEngineer/VesselSimulator/EngineSim.cs
+++ b/KerbalEngineer/VesselSimulator/EngineSim.cs
@@ -198,7 +198,7 @@ namespace KerbalEngineer.VesselSimulator
             for (int i = 0; i < propellants.Count; ++i)
             {
                 Propellant propellant = propellants[i];
-                if (propellant.name == "ElectricCharge" || propellant.name == "IntakeAir")
+                if (propellant.name == "ElectricCharge" || propellant.name == "IntakeAir" || DeltaVGlobals.PropellantsToIgnore.Contains(propellant.name))
                 {
                     continue;
                 }
@@ -211,7 +211,7 @@ namespace KerbalEngineer.VesselSimulator
             {
                 Propellant propellant = propellants[i];
 
-                if (propellant.name == "ElectricCharge" || propellant.name == "IntakeAir")
+                if (propellant.name == "ElectricCharge" || propellant.name == "IntakeAir" || DeltaVGlobals.PropellantsToIgnore.Contains(propellant.name))
                 {
                     continue;
                 }

--- a/KerbalEngineer/VesselSimulator/RCSSim.cs
+++ b/KerbalEngineer/VesselSimulator/RCSSim.cs
@@ -166,7 +166,7 @@ namespace KerbalEngineer.VesselSimulator {
             for (int i = 0; i < propellants.Count; ++i) {
                 Propellant propellant = propellants[i];
 
-                if (propellant.ignoreForIsp || propellant.name == "ElectricCharge" || propellant.name == "IntakeAir") {
+                if (propellant.ignoreForIsp || propellant.name == "ElectricCharge" || propellant.name == "IntakeAir" || || DeltaVGlobals.PropellantsToIgnore.Contains(propellant.name)) {
                     continue;
                 }
 


### PR DESCRIPTION
In order for the DeltaV Calcs to take into account Propellants ignored by stock deltaV Calcs.

Currently, there doesn't seem to be any way to make ressources act like electriccharge in deltaV calcs (ignore it completely). This should (not tested) fix this, by adding a check to the stock list PropellantsToIgnore from DeltaVGlobals, name self explainatory. Unsure if the ElectricCharge and IntakeAir checks would even be necessary, they might already be in PropellantsToIgnore, but i haven't taken that much time looking into every detail.

This is mainly to outline the fact this is not taken into account when calculating deltaV, and it should.